### PR TITLE
View configuration according the status

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,4 +27,4 @@ repos:
     hooks:
       - id: shellcheck
         files: \.sh$
-        args: ["--severity=warning"]
+        args: ["--severity=error"]

--- a/utils.sh
+++ b/utils.sh
@@ -138,3 +138,21 @@ function load_paths(){
     echo "$item"
   done
 }
+
+function get_conf_by_status(){
+  local status="$1"
+  mapfile -t connected < <(jq -r --argjson stat "$status" '.confs[] | select((.connected == $stat) or ($stat == false and .connected == null)) | .path' "$wgbconf")
+
+  for item in "${connected[@]}"; do
+    echo "$item"
+  done
+}
+
+
+function set_connection_status(){
+  local conf="$1"
+  local status=$2
+  jq --arg target "$conf" --argjson status "$status" '(.confs[] | select(.path==$target)) += {connected: $status}' "$wgbconf" > $wgbconf.tmp
+
+  mv $wgbconf.tmp $wgbconf
+}


### PR DESCRIPTION
Add a flag in the configuration to know whether a configuration is in use or not. Also use it to display the correct connection: during connection display only unconnected interfaces, during disconnection display only connected interfaces.

Fixes: #24

<!--- Provide a general summary of your changes in the Title above -->

# Description
A couple of functions have been added to get the list of connections by their status from the configuration file and to set it in the same file.

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reduce the list of configurations when possible and avoid errors caused by incorrect usage

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing the function calling them by a test

# Screenshots (if appropriate)

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
