### PR TITLE
Fix connection listing

### DIFF
--- a/utils.sh
+++ b/utils.sh
@@ -63,7 +63,7 @@ function get_error_msg(){
 # Args    :
 # Returns :
 # -----------------------------------------------------------------------------
-function get_configuration(){
+function init_configuration(){
   if [ -f "$wgbconf" ]; then
     while IFS= read -r item; do
       DIRS+=("$item")

--- a/wg-bridge-completion.sh
+++ b/wg-bridge-completion.sh
@@ -6,7 +6,7 @@ wgbconf="$user_home/.wgbconf.json"
 DIRS=("/etc/wireguard")
 
 # Load user-configured paths
-get_configuration(){
+init_configuration(){
   while IFS= read -r item; do
     DIRS+=("$item")
   done < <(jq -r '.conf_path[]' "$wgbconf" 2>/dev/null)
@@ -14,7 +14,7 @@ get_configuration(){
 
 # Find available configurations
 find_configs(){
-  get_configuration
+  init_configuration
   sudo find "${DIRS[@]}" -type f -name "*.conf" 2>/dev/null
 }
 

--- a/wg-bridge.sh
+++ b/wg-bridge.sh
@@ -5,7 +5,8 @@
 # =============================================================================
 # Usage          : ./wg-bridge.sh [connect, disconnect,list,status,path]
 # =============================================================================
-source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/utils.sh"
+# source "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/utils.sh"
+source "./utils.sh"
 
 
 
@@ -50,7 +51,18 @@ function connect(){
   if [ "$1" != "" ]; then
     conf=$1
   else
-    conf=$(list "$(get_conf_by_status false)")
+    # get configurations connected
+    IFS=$'\n' read -r -d '' -a avail < <(get_conf_by_status true; printf '\0')
+
+    # Get all configurations
+    all=($(find_configs))
+
+    # Construct regex pattern safely
+    pattern=$(printf "|%s" "${avail[@]}")
+    pattern=${pattern:1}  # Remove leading "|"
+
+    # Remove from all configurations those connected
+    conf=$(list "$(printf "%s\n" "${all[@]}" | grep -v -E "^(${pattern})$")")
   fi
   if [ "$conf" != "" ]; then
     istoken=$(handle_token "$conf")
@@ -194,7 +206,7 @@ if [ $# -eq 0 ]; then
   exit 2
 fi
 
-get_configuration
+init_configuration
 
 OPTIONS=vh
 LONGOPTIONS=verbose,help


### PR DESCRIPTION
During the connection activity it displays all available configurations, even those not yet configured. This allows you to add configurations even after the first installation

Fixes: #34

<!--- Provide a general summary of your changes in the Title above -->

# Description
During the connection activity, only configured connections that were not connected were displayed. Now, during the same activity, all connections are displayed, even those not yet configured (so not yet in the `confs` array)

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows to add directories and configurations without writing the configurations to the json file

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Screenshots (if appropriate)

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
