### PR TITLE
Show only connected connections

### DIFF
--- a/wg-bridge.sh
+++ b/wg-bridge.sh
@@ -103,16 +103,19 @@ function disconnect(){
 
 # -----------------------------------------------------------------------------
 # Purpose : Prints the list of configuration files available in the system
-# Args    : show - used only to display the list
+#           or a list passed as arguments
+# Args    : - show - used only to display the full list
+#           - all - used only to display the full list
+#           - array of configurations
+#           'show' and 'all' are two keywords used in diffent way in the code
+#           array of configurations is a list of VPN configuration
 # Returns : The chosen configuration file path
 # -----------------------------------------------------------------------------
 function list(){
-  if [[ "$1" == "show" ]]; then
+  if [ "$1" == "show" ] || [ "$1" == "all" ]; then
     view_prompt "$(find_configs)"
-  elif [ "$1" != "show" ] && [ "$1" != "" ]; then
-    choose=$(view_prompt "$1")
   else
-    choose=$(view_prompt "$(find_configs)")
+    choose=$(view_prompt "$1")
   fi
   echo $choose | cut -d "|" -f2
 }


### PR DESCRIPTION
During disconnection task the prompt must show only the active connections: if there is no active connection the prompt should be empty.

Fixes: #41

<!--- Provide a general summary of your changes in the Title above -->

# Description
<!--- Describe your changes in detail -->
The `list` function has been modified to only display arguments passed to it. This way the list accepts a couple of keywords: `show` and `all` which are both used to display all available connections. All other arguments passed are displayed as is.

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change was necessary because there were many problems when viewing

# How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Screenshots (if appropriate)

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
to change)

# Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here
to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
